### PR TITLE
Overhaul homepage with personal portfolio layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,31 +1,181 @@
-
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Coming Soon</title>
-<style>
-  :root{--bg:#1a1a1a;--fg:#f5f5f5;--muted:#cccccc;--glass:rgba(255,255,255,.08)}
-  html,body{height:100%;margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;background:var(--bg);color:var(--fg);display:flex;align-items:center;justify-content:center;text-align:center}
-  .wrap{max-width:520px;padding:20px}
-  h1{font-size:2.2rem;margin:0 0 .4em;font-weight:600;color:var(--fg)}
-  p{font-size:1.1rem;color:var(--muted);margin:.5em 0 0}
-  .emoji{font-size:3rem;margin-top:.8em;cursor:pointer;display:inline-block;user-select:none;outline:none;transition:transform .15s ease}
-  .emoji:active{transform:translateY(2px) scale(.98)}
-  /* toast */
-  .toast{position:fixed;left:50%;bottom:24px;transform:translateX(-50%) translateY(20px);opacity:0;background:var(--glass);backdrop-filter:blur(10px);padding:10px 14px;border-radius:999px;border:1px solid rgba(255,255,255,.12);color:var(--fg);font-size:.95rem;transition:all .25s ease;pointer-events:none}
-  .toast.show{opacity:1;transform:translateX(-50%) translateY(0)}
-  /* steam particles */
-  .steam{position:absolute;left:0;top:0;font-size:1.1rem;opacity:0;animation:floatUp 1.2s ease-out forwards}
-  @keyframes floatUp{0%{transform:translate(var(--x,0),0) scale(.9);opacity:0}10%{opacity:1}100%{transform:translate(var(--x,0),-80px) scale(1.2);opacity:0}}
-  /* subtle focus ring for accessibility */
-  .emoji:focus{box-shadow:0 0 0 3px rgba(255,255,255,.15);border-radius:8px}
-</style>
-<div class="wrap">
-  <h1>Things are brewing, stay tuned</h1>
-  <p>Something fresh is on the way.</p>
-  <div id="mug" class="emoji" role="button" tabindex="0" aria-label="Secret coffee mug">☕</div>
-</div>
-
-
-</script>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Taiyo Tsuchiya</title>
+  <!-- Fonts: Inter + Yellowtail -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Yellowtail&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    :root {
+      --accent: #FF8C00;
+      --bg: #fafafa;
+      --ink: #333;
+      --muted: #555;
+    }
+    html { scroll-behavior: smooth; }
+    body { font-family: "Inter", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif; line-height: 1.6; background: var(--bg); color: var(--ink); }
+    a { text-decoration: none; color: inherit; }
+    .yellowtail-regular {
+      font-family: "Yellowtail", cursive;
+      font-weight: 400;
+      font-style: normal;
+    }
+    header { position: fixed; top: 0; left: 0; width: 100%; background: #fff; border-bottom: 1px solid #e9e9e9; padding: 0.5rem 2rem; display: flex; justify-content: space-between; align-items: center; z-index: 100; }
+    header h1 { font-size: 1.1rem; font-weight: 700; letter-spacing: .2px; }
+    nav a { margin-left: 1.25rem; font-weight: 600; opacity: .9; transition: color .2s, opacity .2s; }
+    nav a:hover { color: var(--accent); opacity: 1; }
+    nav a::before { content: attr(data-number) " "; font-weight: 800; color: var(--accent); }
+    main { padding-top: 50px; }
+    .hero { min-height: clamp(350px, 55vh, 550px); display: grid; grid-template-columns: 1.1fr 1.2fr; gap: clamp(20px, 3vw, 36px); align-items: center; padding: clamp(12px, 2vw, 24px) clamp(20px, 6vw, 96px) clamp(8px, 1vw, 16px); }
+    .hero-left { display: grid; place-items: center; }
+    .hero-figure { width: min(360px, 42vw); aspect-ratio: 1/1; border-radius: 100%; background: #fff; border: 6px solid var(--accent); padding: 10px; display: grid; place-items: center; box-shadow: 0 6px 24px rgba(0,0,0,.08); }
+    .hero-figure img { 
+      width: 100%; 
+      height: 100%; 
+      object-fit: contain; 
+      border-radius: 100%;
+      padding: 10px;
+    }
+    .hero-right { max-width: 680px; }
+    .kicker { font-family: "Inter", sans-serif; font-size: clamp(40px, 2.2vw, 22px); font-weight: 700; color: var(--ink); margin-bottom: .4rem; }
+    .hero-title { font-family: "Inter", sans-serif; font-weight: 800; letter-spacing: .2px; font-size: clamp(36px, 6vw, 56px); line-height: 1.1; margin-bottom: .25rem; }
+    .hero-script { font-family: "Yellowtail", cursive; font-size: clamp(24px, 4.5vw, 40px); color: var(--accent); margin-bottom: .75rem; }
+    .hero-sub { font-size: clamp(16px, 2vw, 18px); color: var(--muted); max-width: 54ch; }
+    
+    /* Updated asymmetrical bento grid matching the drawing */
+    .bento {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 8px clamp(8px, 5vw, 32px) 40px;
+      display: grid;
+      grid-template-columns: 2fr 1fr 2fr;
+      grid-template-rows: 1fr 1fr;
+      gap: 8px;
+      height: 700px;
+    }
+    
+    .box {
+      background: #fff;
+      border-radius: 24px;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.06);
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      padding: clamp(22px, 2.8vw, 36px) clamp(18px, 3vw, 34px);
+      transition: transform .2s, box-shadow .2s;
+      position: relative;
+    }
+    
+    .box:hover { transform: translateY(-4px); box-shadow: 0 8px 20px rgba(0,0,0,0.09); }
+    .box h3 { margin-bottom: 8px; color: var(--accent); font-size: clamp(21px, 2.5vw, 26px); text-align: center; }
+    .box p { color: var(--muted); margin-bottom: 18px; text-align: center; }
+    .cta { display: inline-block; padding: 12px 20px; background: var(--accent); color: #fff; border-radius: 13px; font-size: 1.04rem; font-weight: 700; letter-spacing: .16px; text-align: center; box-shadow: 0 1px 6px rgba(255,140,0,0.05); }
+    .cta:hover { filter: brightness(.95); }
+    
+    /* Layout with 3 columns to get equal spacing:
+      [ projects (spans 2) | about (1) ]
+      [ experience (1) | blog (spans 2) ]
+    */
+    .box.projects { 
+      grid-row: 1 / 2; 
+      grid-column: 1 / 3; 
+    }
+    .box.about { 
+      grid-row: 1 / 2; 
+      grid-column: 3 / 4; 
+    }
+    .box.experience { 
+      grid-row: 2 / 3; 
+      grid-column: 1 / 2; 
+    }
+    .box.blog { 
+      grid-row: 2 / 3; 
+      grid-column: 2 / 4; 
+    }
+    
+    @media (max-width: 900px) {
+      .bento { 
+        grid-template-columns: 1fr; 
+        grid-template-rows: repeat(4, 200px);
+        height: auto;
+        gap: 8px;
+      }
+      .box, .box.projects, .box.about, .box.experience, .box.blog { 
+        grid-column: 1 / 2;
+      }
+      .box.projects { grid-row: 1 / 2; }
+      .box.about { grid-row: 2 / 3; }
+      .box.experience { grid-row: 3 / 4; }
+      .box.blog { grid-row: 4 / 5; }
+      .bottom-row {
+        display: contents;
+      }
+    }
+    
+    footer { background: #222; color: #fff; text-align: center; padding: 2rem 1rem; }
+    .socials a { margin: 0 .5rem; color: #fff; font-weight: 700; }
+    .socials a:hover { color: var(--accent); }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Taiyo Tsuchiya</h1>
+    <nav>
+      <a href="#work" data-number="01">Work</a>
+      <a href="#experience" data-number="02">Experience</a>
+      <a href="#blog" data-number="03">Blog</a>
+      <a href="#about" data-number="04">About</a>
+    </nav>
+  </header>
+  <main>
+    <section class="hero">
+      <div class="hero-left">
+        <figure class="hero-figure">
+          <img src="43cfe88e-d455-4fec-8ae9-6a5652bca4b6.png" alt="Taiyo profile" />
+        </figure>
+      </div>
+      <div class="hero-right">
+        <div class="kicker">Hi, I'm Taiyo</div>
+        <div class="hero-script yellowtail-regular">Nice to meet you!</div>
+        <p class="hero-sub">Browse my work, experience, blog, and background</p>
+      </div>
+    </section>
+    <section class="bento">
+      <div class="box projects" id="work">
+        <h3>Recent Projects</h3>
+        <p>Selected projects and visual experiments.</p>
+        <a href="#" class="cta">Explore Work</a>
+      </div>
+      <div class="box about" id="about">
+        <h3>About Me</h3>
+        <p>Background, values, and what I'm building next.</p>
+        <a href="#" class="cta">Learn More</a>
+      </div>
+      <div class="box experience" id="experience">
+        <h3>Experience</h3>
+        <p>Roles, contributions, and what I shipped.</p>
+        <a href="#" class="cta">View Resume</a>
+      </div>
+      <div class="box blog" id="blog">
+        <h3>Blog</h3>
+        <p>Notes, breakdowns, and occasional deep dives.</p>
+        <a href="#" class="cta">Read Posts</a>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <p>Connect with me:</p>
+    <div class="socials">
+      <a href="#">Instagram</a>
+      <a href="#">X / Twitter</a>
+      <a href="#">Threads</a>
+      <a href="#">YouTube</a>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Replace coming-soon stub with a full portfolio design including hero, bento grid, and footer

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b2ddd4d74c8330896c6e1d5a141892